### PR TITLE
Fix asset browser activation and delete safety

### DIFF
--- a/katla_app/src/ui/editor_ui/asset_browser/mod.rs
+++ b/katla_app/src/ui/editor_ui/asset_browser/mod.rs
@@ -11,3 +11,4 @@ mod types;
 
 pub use state::AssetBrowserState;
 pub use types::{AssetAction, AssetType, ThumbnailState};
+pub(crate) use types::AssetEntry;

--- a/katla_app/src/ui/editor_ui/asset_browser/state.rs
+++ b/katla_app/src/ui/editor_ui/asset_browser/state.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::Instant;
 
-use katla_ui::ScrollAreaState;
+use katla_ui::{ScrollAreaState, input::DOUBLE_CLICK_TIME};
 
 use super::types::{AssetAction, AssetEntry, AssetType, ThumbnailState};
 
@@ -49,6 +49,10 @@ pub struct AssetBrowserState {
     pub(crate) confirm_pending_action: Option<AssetAction>,
     /// Last computed column count from the rendering pass, used for keyboard navigation.
     pub(crate) last_col_count: usize,
+    /// Asset index from the first click in a possible double-click sequence.
+    last_click_index: Option<usize>,
+    /// Time of the first click in a possible double-click sequence.
+    last_click_time: Option<Instant>,
 }
 
 impl AssetBrowserState {
@@ -78,6 +82,8 @@ impl AssetBrowserState {
             confirm_dialog_message: String::new(),
             confirm_pending_action: None,
             last_col_count: 8,
+            last_click_index: None,
+            last_click_time: None,
         }
     }
 
@@ -93,6 +99,8 @@ impl AssetBrowserState {
             .collect();
 
         self.assets.clear();
+        self.last_click_index = None;
+        self.last_click_time = None;
 
         if let Some(parent) = self.current_path.parent()
             && parent != self.current_path
@@ -284,6 +292,29 @@ impl AssetBrowserState {
         }
     }
 
+    /// Register a click and return true only for a valid second click on the same asset.
+    pub(crate) fn register_click(&mut self, asset_index: usize) -> bool {
+        self.register_click_at(asset_index, Instant::now())
+    }
+
+    fn register_click_at(&mut self, asset_index: usize, now: Instant) -> bool {
+        let is_double_click = self.last_click_index == Some(asset_index)
+            && self.last_click_time.is_some_and(|last| {
+                now.checked_duration_since(last)
+                    .is_some_and(|elapsed| elapsed.as_secs_f64() <= DOUBLE_CLICK_TIME)
+            });
+
+        if is_double_click {
+            self.last_click_index = None;
+            self.last_click_time = None;
+        } else {
+            self.last_click_index = Some(asset_index);
+            self.last_click_time = Some(now);
+        }
+
+        is_double_click
+    }
+
     /// Take pending actions, clearing the list.
     pub fn take_actions(&mut self) -> Vec<AssetAction> {
         std::mem::take(&mut self.pending_actions)
@@ -293,5 +324,32 @@ impl AssetBrowserState {
 impl Default for AssetBrowserState {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn double_click_requires_same_asset_within_time_window() {
+        let mut state = AssetBrowserState::new();
+        let start = Instant::now();
+
+        assert!(!state.register_click_at(1, start));
+        assert!(!state.register_click_at(2, start + Duration::from_millis(100)));
+        assert!(state.register_click_at(2, start + Duration::from_millis(200)));
+    }
+
+    #[test]
+    fn click_after_timeout_starts_a_new_sequence() {
+        let mut state = AssetBrowserState::new();
+        let start = Instant::now();
+
+        assert!(!state.register_click_at(3, start));
+        assert!(!state.register_click_at(3, start + Duration::from_millis(600)));
+        assert!(state.register_click_at(3, start + Duration::from_millis(700)));
     }
 }

--- a/katla_app/src/ui/editor_ui/declarative/asset_browser.rs
+++ b/katla_app/src/ui/editor_ui/declarative/asset_browser.rs
@@ -14,7 +14,9 @@ use katla_ui::{FontSize, ForkAwesome, TextureId};
 use crate::ui::ColorScheme;
 use crate::ui::editor_ui::EditorAction;
 use crate::ui::editor_ui::ThumbnailState;
-use crate::ui::editor_ui::asset_browser::{AssetAction, AssetBrowserState, AssetType};
+use crate::ui::editor_ui::asset_browser::{
+    AssetAction, AssetBrowserState, AssetEntry, AssetType,
+};
 
 /// Environment data injected before each frame for the asset browser panel.
 #[derive(Clone)]
@@ -51,15 +53,11 @@ pub(crate) enum AssetBrowserAction {
     NavigateForward,
     Refresh,
     AssetClicked(usize),
-    AssetDoubleClicked {
-        path: PathBuf,
-        asset_type: AssetType,
-    },
     ContextMenuAction {
         action: String,
         asset_index: Option<usize>,
     },
-    ConfirmDelete(PathBuf),
+    ConfirmDelete,
     CancelDelete,
 }
 
@@ -80,13 +78,14 @@ impl Build for AssetBrowserView {
         let scroll_id: StateId = ctx.state(0.0f32);
         let context_open_id: StateId = ctx.state(draw_ctx.context_menu_open);
         let confirm_open_id: StateId = ctx.state(draw_ctx.confirm_dialog_open);
+        ctx.set_state(context_open_id, draw_ctx.context_menu_open);
         ctx.set_state(confirm_open_id, draw_ctx.confirm_dialog_open);
+
         let search_filter: String = ctx
             .get_state(search_id)
             .unwrap_or_else(|| draw_ctx.search_filter.clone());
         let search_lower = search_filter.to_lowercase();
 
-        // Breadcrumbs
         let mut breadcrumb_items: Vec<Box<dyn Widget>> = Vec::new();
         for (i, segment) in draw_ctx.path_segments.iter().enumerate() {
             if i > 0 {
@@ -97,6 +96,7 @@ impl Build for AssetBrowserView {
                         .boxed(),
                 );
             }
+
             let is_last = i == draw_ctx.path_segments.len() - 1;
             if is_last {
                 breadcrumb_items.push(
@@ -106,20 +106,19 @@ impl Build for AssetBrowserView {
                         .boxed(),
                 );
             } else {
-                let seg_index = i;
+                let segment_index = i;
                 breadcrumb_items.push(
                     button(segment)
                         .fill(katla_math::Color::TRANSPARENT)
                         .border(katla_math::Color::TRANSPARENT)
                         .on_click(ctx.on_click(move |actions| {
-                            actions.emit(AssetBrowserAction::NavigateToSegment(seg_index));
+                            actions.emit(AssetBrowserAction::NavigateToSegment(segment_index));
                         }))
                         .boxed(),
                 );
             }
         }
 
-        // Navigation buttons
         let back_cb = ctx.on_click(|actions| {
             actions.emit(AssetBrowserAction::NavigateBack);
         });
@@ -149,7 +148,6 @@ impl Build for AssetBrowserView {
         .padding(Padding::all(4.0))
         .boxed();
 
-        // Grid of assets
         let item_size = 80.0;
         let cell_size = Vec2::new(item_size + 16.0, item_size + 32.0);
         let col_count = if draw_ctx.bounds.width() > 0.0 {
@@ -185,7 +183,6 @@ impl Build for AssetBrowserView {
             };
 
             let display_name = truncate_name(&asset.name, 12);
-
             let cell = vstack([
                 icon_content,
                 text(display_name)
@@ -198,18 +195,11 @@ impl Build for AssetBrowserView {
             .align(katla_ui::declarative::Alignment::Center);
 
             let click_index = i;
-            let click_path = asset.path.clone();
-            let click_type = asset.asset_type;
-
             grid_children.push(
                 selectable(cell.boxed())
                     .selected(is_selected)
                     .on_click(ctx.on_click(move |actions| {
                         actions.emit(AssetBrowserAction::AssetClicked(click_index));
-                        actions.emit(AssetBrowserAction::AssetDoubleClicked {
-                            path: click_path.clone(),
-                            asset_type: click_type,
-                        });
                     }))
                     .boxed(),
             );
@@ -234,18 +224,18 @@ impl Build for AssetBrowserView {
         let content = vstack([
             toolbar,
             separator_horizontal().boxed(),
-            scroll(grid_content, scroll_id).boxed(),
+            scroll(grid_content, scroll_id).flex_grow(1.0).boxed(),
         ])
+        .flex_grow(1.0)
         .boxed();
 
-        // Context menu
         let context_items: Vec<katla_ui::declarative::ContextMenuEntry> =
             if draw_ctx.context_menu_is_asset {
                 vec![
                     context_entry("Open").on_click(ctx.on_click(|actions| {
                         actions.emit(AssetBrowserAction::ContextMenuAction {
                             action: "Open".to_string(),
-                            asset_index: None, // resolved from state in processor
+                            asset_index: None,
                         });
                     })),
                     context_entry("Rename").on_click(ctx.on_click(|actions| {
@@ -279,7 +269,7 @@ impl Build for AssetBrowserView {
                         actions.emit(AssetBrowserAction::ContextMenuAction {
                             action: "New Folder".to_string(),
                             asset_index: None,
-                        })
+                        });
                     })),
                     context_entry("Refresh").on_click(ctx.on_click(|actions| {
                         actions.emit(AssetBrowserAction::ContextMenuAction {
@@ -296,21 +286,20 @@ impl Build for AssetBrowserView {
                 ]
             };
 
-        let ctx_menu = context_menu(context_items, context_open_id).boxed();
+        let context_menu = context_menu(context_items, context_open_id).boxed();
 
-        // Confirmation modal
-        let no_btn = button("No")
+        let no_button = button("No")
             .fill(katla_math::Color::TRANSPARENT)
             .border(katla_math::Color::TRANSPARENT)
             .on_click(ctx.on_click(|actions| {
                 actions.emit(AssetBrowserAction::CancelDelete);
             }))
             .boxed();
-        let yes_btn = button("Yes")
+        let yes_button = button("Yes")
             .fill(draw_ctx.theme.error.with_alpha(0.3))
             .border(katla_math::Color::TRANSPARENT)
             .on_click(ctx.on_click(|actions| {
-                actions.emit(AssetBrowserAction::ConfirmDelete(PathBuf::new()));
+                actions.emit(AssetBrowserAction::ConfirmDelete);
             }))
             .boxed();
 
@@ -321,7 +310,7 @@ impl Build for AssetBrowserView {
             text(&draw_ctx.confirm_dialog_message)
                 .color(draw_ctx.theme.text_secondary)
                 .boxed(),
-            hstack([no_btn, yes_btn]).spacing(8.0).boxed(),
+            hstack([no_button, yes_button]).spacing(8.0).boxed(),
         ])
         .spacing(8.0)
         .padding_all(8.0);
@@ -334,7 +323,9 @@ impl Build for AssetBrowserView {
 
         panel(
             "Asset Browser",
-            vstack([content, ctx_menu, confirm_modal.boxed()]).boxed(),
+            vstack([content, context_menu, confirm_modal.boxed()])
+                .flex_grow(1.0)
+                .boxed(),
         )
         .flex_width(draw_ctx.bounds.width())
         .flex_height(draw_ctx.bounds.height())
@@ -347,6 +338,29 @@ fn truncate_name(name: &str, max_chars: usize) -> String {
         format!("{}...", name.chars().take(max_chars).collect::<String>())
     } else {
         name.to_string()
+    }
+}
+
+fn activate_asset(
+    state: &mut AssetBrowserState,
+    asset: AssetEntry,
+    thumbnail_texture_handles: &HashMap<PathBuf, TextureHandle>,
+) {
+    match asset.asset_type {
+        AssetType::Folder => {
+            if asset.name == ".." {
+                state.navigate_up(thumbnail_texture_handles);
+            } else {
+                state.navigate_to(&asset.path, thumbnail_texture_handles);
+            }
+        }
+        AssetType::Model => state
+            .pending_actions
+            .push(AssetAction::ModelPreviewRequested(asset.path)),
+        AssetType::Audio => state
+            .pending_actions
+            .push(AssetAction::AudioPreviewToggle { path: asset.path }),
+        _ => {}
     }
 }
 
@@ -374,23 +388,28 @@ pub(crate) fn process_asset_actions(
                     new_folder = parent_path.join(format!("New Folder {}", counter));
                     counter += 1;
                 }
-                if let Err(e) = std::fs::create_dir(&new_folder) {
-                    log::warn!("Failed to create folder: {}", e);
+                if let Err(error) = std::fs::create_dir(&new_folder) {
+                    log::warn!("Failed to create folder: {}", error);
                 } else {
                     log::info!("Created folder: {:?}", new_folder);
                     state.scan_directory(thumbnail_texture_handles);
                 }
             }
             AssetAction::Delete(path) => {
+                if path.as_os_str().is_empty() {
+                    log::warn!("Refusing to delete an empty asset path");
+                    continue;
+                }
+
                 if path.is_dir() {
-                    if let Err(e) = std::fs::remove_dir_all(&path) {
-                        log::warn!("Failed to delete folder: {}", e);
+                    if let Err(error) = std::fs::remove_dir_all(&path) {
+                        log::warn!("Failed to delete folder: {}", error);
                     } else {
                         log::info!("Deleted folder: {:?}", path);
                         state.scan_directory(thumbnail_texture_handles);
                     }
-                } else if let Err(e) = std::fs::remove_file(&path) {
-                    log::warn!("Failed to delete file: {}", e);
+                } else if let Err(error) = std::fs::remove_file(&path) {
+                    log::warn!("Failed to delete file: {}", error);
                 } else {
                     log::info!("Deleted file: {:?}", path);
                     state.scan_directory(thumbnail_texture_handles);
@@ -409,29 +428,29 @@ pub(crate) fn process_asset_actions(
             AssetAction::ShowInExplorer(path) => {
                 #[cfg(target_os = "windows")]
                 {
-                    if let Err(e) = std::process::Command::new("explorer")
+                    if let Err(error) = std::process::Command::new("explorer")
                         .args(["/select,", &path.to_string_lossy()])
                         .spawn()
                     {
-                        log::warn!("Failed to open explorer: {}", e);
+                        log::warn!("Failed to open explorer: {}", error);
                     }
                 }
                 #[cfg(target_os = "macos")]
                 {
-                    if let Err(e) = std::process::Command::new("open")
+                    if let Err(error) = std::process::Command::new("open")
                         .args(["-R", &path.to_string_lossy()])
                         .spawn()
                     {
-                        log::warn!("Failed to open finder: {}", e);
+                        log::warn!("Failed to open finder: {}", error);
                     }
                 }
                 #[cfg(target_os = "linux")]
                 {
-                    if let Err(e) = std::process::Command::new("xdg-open")
+                    if let Err(error) = std::process::Command::new("xdg-open")
                         .arg(path.parent().unwrap_or(&path))
                         .spawn()
                     {
-                        log::warn!("Failed to open file manager: {}", e);
+                        log::warn!("Failed to open file manager: {}", error);
                     }
                 }
             }
@@ -453,8 +472,8 @@ pub(crate) fn process_declarative_actions(
 
     for action in actions {
         match action {
-            AssetBrowserAction::NavigateToSegment(idx) => {
-                state.navigate_to_segment(idx, thumbnail_texture_handles);
+            AssetBrowserAction::NavigateToSegment(index) => {
+                state.navigate_to_segment(index, thumbnail_texture_handles);
             }
             AssetBrowserAction::NavigateBack => {
                 state.navigate_back(thumbnail_texture_handles);
@@ -465,89 +484,77 @@ pub(crate) fn process_declarative_actions(
             AssetBrowserAction::Refresh => {
                 state.refresh(thumbnail_texture_handles);
             }
-            AssetBrowserAction::AssetClicked(idx) => {
-                state.selected_index = Some(idx);
+            AssetBrowserAction::AssetClicked(index) => {
+                let activate = state.register_click(index);
+                state.selected_index = Some(index);
                 state.selected_indices.clear();
-            }
-            AssetBrowserAction::AssetDoubleClicked {
-                asset_type, path, ..
-            } => {
-                if asset_type == AssetType::Folder {
-                    if path.ends_with("..") {
-                        state.navigate_up(thumbnail_texture_handles);
-                    } else {
-                        state.navigate_to(&path, thumbnail_texture_handles);
-                    }
-                } else if asset_type == AssetType::Model {
-                    state
-                        .pending_actions
-                        .push(AssetAction::ModelPreviewRequested(path));
-                } else if asset_type == AssetType::Audio {
-                    state
-                        .pending_actions
-                        .push(AssetAction::AudioPreviewToggle { path });
+
+                if activate
+                    && let Some(asset) = state.assets.get(index).cloned()
+                {
+                    activate_asset(state, asset, thumbnail_texture_handles);
                 }
             }
             AssetBrowserAction::ContextMenuAction {
                 action,
                 asset_index,
             } => {
-                let asset_path = asset_index
-                    .and_then(|idx| state.assets.get(idx))
-                    .map(|a| a.path.clone())
-                    .unwrap_or_else(|| state.current_path.clone());
-                let asset_type = asset_index
-                    .and_then(|idx| state.assets.get(idx))
-                    .map(|a| a.asset_type);
+                let resolved_index = asset_index.or(state.context_menu_asset);
+                let target = resolved_index.and_then(|index| state.assets.get(index)).cloned();
 
                 state.context_menu_open = false;
                 state.context_menu_asset = None;
 
                 match action.as_str() {
                     "Open" => {
-                        if asset_type == Some(AssetType::Folder) {
-                            if asset_path.file_name().map(|n| n == "..").unwrap_or(false) {
-                                state.navigate_up(thumbnail_texture_handles);
-                            } else {
-                                state.navigate_to(&asset_path, thumbnail_texture_handles);
-                            }
-                        } else if asset_type.is_some() {
-                            state.pending_actions.push(AssetAction::Open(asset_path));
+                        if let Some(asset) = target {
+                            activate_asset(state, asset, thumbnail_texture_handles);
                         }
                     }
                     "Rename" => {
-                        if let Some(idx) = asset_index {
-                            state.start_rename(idx);
+                        if let Some(index) = resolved_index {
+                            state.start_rename(index);
                         }
                     }
                     "Copy Path" => {
-                        state
-                            .pending_actions
-                            .push(AssetAction::CopyPath(asset_path));
+                        if let Some(asset) = target {
+                            state
+                                .pending_actions
+                                .push(AssetAction::CopyPath(asset.path));
+                        }
                     }
                     "Show in Explorer" => {
+                        let path = target
+                            .map(|asset| asset.path)
+                            .unwrap_or_else(|| state.current_path.clone());
                         state
                             .pending_actions
-                            .push(AssetAction::ShowInExplorer(asset_path));
+                            .push(AssetAction::ShowInExplorer(path));
                     }
                     "Delete" => {
-                        let is_folder = asset_path.is_dir();
-                        let name = asset_path
-                            .file_name()
-                            .map(|n| n.to_string_lossy().to_string())
-                            .unwrap_or_else(|| "this item".to_string());
-                        state.confirm_dialog_message = if is_folder {
-                            format!("Delete folder \"{}\" and all its contents?", name)
-                        } else {
-                            format!("Delete \"{}\"?", name)
-                        };
-                        state.confirm_pending_action = Some(AssetAction::Delete(asset_path));
-                        state.confirm_dialog_open = true;
+                        if let Some(asset) = target {
+                            if asset.name == ".." {
+                                log::warn!("Refusing to delete the parent-directory entry");
+                            } else {
+                                let is_folder = asset.asset_type == AssetType::Folder;
+                                state.confirm_dialog_message = if is_folder {
+                                    format!(
+                                        "Delete folder \"{}\" and all its contents?",
+                                        asset.name
+                                    )
+                                } else {
+                                    format!("Delete \"{}\"?", asset.name)
+                                };
+                                state.confirm_pending_action =
+                                    Some(AssetAction::Delete(asset.path));
+                                state.confirm_dialog_open = true;
+                            }
+                        }
                     }
                     "New Folder" => {
                         state
                             .pending_actions
-                            .push(AssetAction::CreateFolder(asset_path));
+                            .push(AssetAction::CreateFolder(state.current_path.clone()));
                     }
                     "Refresh" => {
                         state.refresh(thumbnail_texture_handles);
@@ -555,9 +562,11 @@ pub(crate) fn process_declarative_actions(
                     _ => {}
                 }
             }
-            AssetBrowserAction::ConfirmDelete(path) => {
+            AssetBrowserAction::ConfirmDelete => {
                 state.confirm_dialog_open = false;
-                state.pending_actions.push(AssetAction::Delete(path));
+                if let Some(action) = state.confirm_pending_action.take() {
+                    state.pending_actions.push(action);
+                }
             }
             AssetBrowserAction::CancelDelete => {
                 state.confirm_dialog_open = false;
@@ -566,7 +575,6 @@ pub(crate) fn process_declarative_actions(
         }
     }
 
-    // Process any pending AssetActions that were queued by the action handlers
     pending.extend(process_asset_actions(
         state,
         thumbnail_texture_handles,
@@ -574,4 +582,120 @@ pub(crate) fn process_declarative_actions(
     ));
 
     pending
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn audio_asset(path: &str) -> AssetEntry {
+        AssetEntry {
+            name: "sound.wav".to_string(),
+            path: PathBuf::from(path),
+            asset_type: AssetType::Audio,
+            thumbnail_state: ThumbnailState::Pending,
+        }
+    }
+
+    #[test]
+    fn asset_activation_requires_second_click() {
+        let mut state = AssetBrowserState::new();
+        let audio_path = PathBuf::from("resources/sound.wav");
+        state.assets.push(audio_asset("resources/sound.wav"));
+        let handles = HashMap::new();
+        let bounds = Rect2D::default();
+
+        let first = process_declarative_actions(
+            &mut state,
+            &handles,
+            bounds,
+            vec![AssetBrowserAction::AssetClicked(0)],
+        );
+        assert!(first.is_empty());
+
+        let second = process_declarative_actions(
+            &mut state,
+            &handles,
+            bounds,
+            vec![AssetBrowserAction::AssetClicked(0)],
+        );
+        assert!(matches!(
+            second.as_slice(),
+            [EditorAction::AudioPreviewToggle { path }] if path == &audio_path
+        ));
+    }
+
+    #[test]
+    fn confirm_delete_uses_the_stored_pending_action() {
+        let mut state = AssetBrowserState::new();
+        let audio_path = PathBuf::from("resources/pending.wav");
+        state.confirm_dialog_open = true;
+        state.confirm_pending_action = Some(AssetAction::AudioPreviewToggle {
+            path: audio_path.clone(),
+        });
+
+        let actions = process_declarative_actions(
+            &mut state,
+            &HashMap::new(),
+            Rect2D::default(),
+            vec![AssetBrowserAction::ConfirmDelete],
+        );
+
+        assert!(!state.confirm_dialog_open);
+        assert!(state.confirm_pending_action.is_none());
+        assert!(matches!(
+            actions.as_slice(),
+            [EditorAction::AudioPreviewToggle { path }] if path == &audio_path
+        ));
+    }
+
+    #[test]
+    fn context_menu_uses_the_asset_index_stored_in_state() {
+        let mut state = AssetBrowserState::new();
+        let audio_path = PathBuf::from("resources/context.wav");
+        state.assets.push(audio_asset("resources/context.wav"));
+        state.context_menu_open = true;
+        state.context_menu_asset = Some(0);
+
+        let actions = process_declarative_actions(
+            &mut state,
+            &HashMap::new(),
+            Rect2D::default(),
+            vec![AssetBrowserAction::ContextMenuAction {
+                action: "Open".to_string(),
+                asset_index: None,
+            }],
+        );
+
+        assert!(matches!(
+            actions.as_slice(),
+            [EditorAction::AudioPreviewToggle { path }] if path == &audio_path
+        ));
+    }
+
+    #[test]
+    fn parent_directory_entry_cannot_be_deleted() {
+        let mut state = AssetBrowserState::new();
+        state.assets.push(AssetEntry {
+            name: "..".to_string(),
+            path: PathBuf::from("resources"),
+            asset_type: AssetType::Folder,
+            thumbnail_state: ThumbnailState::Pending,
+        });
+        state.context_menu_asset = Some(0);
+
+        let actions = process_declarative_actions(
+            &mut state,
+            &HashMap::new(),
+            Rect2D::default(),
+            vec![AssetBrowserAction::ContextMenuAction {
+                action: "Delete".to_string(),
+                asset_index: None,
+            }],
+        );
+
+        assert!(actions.is_empty());
+        assert!(!state.confirm_dialog_open);
+        assert!(state.confirm_pending_action.is_none());
+    }
 }

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -8,6 +8,7 @@ What is being worked on right now. **Update this file when starting or finishing
 - **State slot stability** — ConsoleView and MixerView now always call `ctx.state()` unconditionally (even when their env is not set) to prevent slot shifts that corrupt DockSpace/Toolbar state IDs when tabs become active.
 - **DockSpace global input** — DockSpace remains non-interactive for normal hit testing so panels underneath receive input, but owns tab and splitter interaction through the declarative global-input pass. There is no separate editor-side dock input path.
 - **Selectable flex_grow opt-in** — Selectable widget defaults to `flex_grow: 0.0` (content-sized) instead of `1.0` (fill parent). Call `.flex_grow(1.0)` where fill behavior is needed.
+- **Asset browser click semantics** — the first click selects an asset; a second click on the same asset within the UI double-click window activates it. Destructive context actions resolve the stored asset index and never fall back to deleting the current directory.
 
 ## Architecture Note
 
@@ -21,6 +22,7 @@ What is being worked on right now. **Update this file when starting or finishing
 - Splitter drag ratios are computed against the bounds of the split node being resized, including nested splits.
 - Dock tab move actions carry the exact dragged tab; the editor preserves that identity when applying the tree mutation.
 - Console level filters and Clear emit typed actions that are applied after the declarative frame.
+- Asset browser confirmation dialogs store the pending `AssetAction`; confirmation consumes that exact action rather than reconstructing a path from UI data.
 
 ## UI Design Target
 
@@ -38,6 +40,8 @@ What is being worked on right now. **Update this file when starting or finishing
 
 ## Recent Decisions
 
+- Asset browser activation is derived from repeated `AssetClicked` actions tracked in `AssetBrowserState`; grid cells do not emit activation on every click.
+- Asset deletion refuses empty paths and the synthetic `..` parent entry.
 - Default theme is "rcp" (Reality Composer Pro): neutral dark #1E1E1E, muted orange #D97706 accent. "default" and "catppuccin" keys still map to RCP for backward compat. Preferences dropdown lists RCP first.
 - RCP selection colors: primary #D97706 (amber), hover #E8913A (warm orange), highlight #B45309 (dark amber)
 - Asset browser now uses `panel()` like other docked panels — provides background fill and tab bar padding

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -4,6 +4,7 @@ What's been done and what's next. **Update this file when completing or starting
 
 ## Completed Recently
 
+- Fixed asset browser action safety: single clicks now select without immediately opening folders or previews, double-click activation is tracked per asset, context actions resolve the stored asset index, delete confirmation consumes the exact pending action, and deletion refuses empty paths plus the synthetic `..` entry. Added regression tests for click activation, stored confirmation actions, context target resolution, and parent-entry protection.
 - Restored complete editor docking interaction: DockSpace now owns tab activation, tab drag/drop, and splitter dragging through the declarative global-input pass; the duplicate manual editor input path was removed. Nested splitter ratios use local split bounds, and tab moves preserve the exact dragged tab. Added regression tests for nested ratios and non-first-tab moves.
 - Wired the Console toolbar: level buttons toggle their filters and Clear empties the shared log buffer through typed declarative actions.
 - Fixed declarative input state regressions: Hierarchy, Asset Browser, and Console now filter from their live text-field `StateId` values, and `UiContext` preserves input consumption across multiple passes within a frame. Added tests for consumption accumulation and frame reset.


### PR DESCRIPTION
## Summary

- make a single asset click select only; activation now requires a second click on the same asset within the UI double-click window
- track click sequences in `AssetBrowserState` and reset them when directory contents change
- resolve context-menu actions from the stored asset index instead of falling back to the current directory
- confirm the exact stored pending action instead of emitting a delete for an empty `PathBuf`
- refuse destructive actions for empty paths and the synthetic `..` parent-directory entry
- let the asset grid's scroll area grow to fill the panel
- add regression tests for double-click activation, confirmation payloads, context-menu targeting, and parent-entry protection
- preserve the docking/console memory-bank updates from merged PR #17

## Bugs fixed

Previously every grid click emitted both `AssetClicked` and `AssetDoubleClicked`, so one click could enter a folder or start a preview. The confirmation button emitted `ConfirmDelete(PathBuf::new())`, and asset context actions passed no index, which could make destructive actions target the current directory.

## Conflict resolution

Rebased the branch onto `main` after PR #17 was merged. Both sets of memory-bank changes are preserved; the branch is no longer behind `main`.

## Validation

- reviewed the complete branch diff against current `main`
- added deterministic click-window tests in `AssetBrowserState`
- added action-processing tests covering selection/activation and delete targeting
- `cargo fmt`, `cargo clippy`, and `cargo test` could not be executed through the connected GitHub environment and must run before merge